### PR TITLE
Allow to find openGL headers on various platforms

### DIFF
--- a/QtFont3D.cpp
+++ b/QtFont3D.cpp
@@ -7,7 +7,12 @@
 
 #include <stdexcept>
 
-#include <glu.h>
+#include <qopengl.h>
+#ifndef Q_OS_DARWIN
+#include <GL/glu.h>
+#else
+#include <OpenGL/glu.h>
+#endif
 
 #include <QList>
 #include <QPainter>


### PR DESCRIPTION
Include OpenGL from the right location according to OS target.
On Linux, the code `#include <glu.h>` does not work.